### PR TITLE
Premake generator: change Android_ to Android- platforms

### DIFF
--- a/generate_premake.py
+++ b/generate_premake.py
@@ -36,8 +36,8 @@ class Config():
 supported_configs = [
     Config('windows', 'x86_64' , 'config_windows_x86_64.h' , 'platforms:Windows'),
     Config('linux'  , 'x86_64' , 'config_linux_x86_64.h'   , 'platforms:Linux'),
-    Config('android', 'x86_64' , 'config_android_x86_64.h' , 'platforms:Android_x86_64'),
-    Config('android', 'aarch64', 'config_android_aarch64.h', 'platforms:Android_ARM64'),
+    Config('android', 'x86_64' , 'config_android_x86_64.h' , 'platforms:Android-x86_64'),
+    Config('android', 'aarch64', 'config_android_aarch64.h', 'platforms:Android-ARM64'),
 ]
 
 def are_list_items_identical(list_a, list_b):

--- a/libavcodec/premake5.lua
+++ b/libavcodec/premake5.lua
@@ -111,14 +111,14 @@ project("libavcodec")
 
   -- libavcodec/aarch64/Makefile:
   --   OBJS:
-  filter({"platforms:Android_ARM64"})
+  filter({"platforms:Android-ARM64"})
   files({
     "aarch64/fft_init_aarch64.c",
     "aarch64/idctdsp_init_aarch64.c",
   })
   filter({})
   --   NEON-OBJS:
-  filter({"platforms:Android_ARM64"})
+  filter({"platforms:Android-ARM64"})
   files({
     "aarch64/fft_neon.S",
     "aarch64/simple_idct_neon.S",
@@ -128,7 +128,7 @@ project("libavcodec")
 
   -- libavcodec/x86/Makefile:
   --   OBJS:
-  filter({"platforms:Android_x86_64 or platforms:Linux or platforms:Windows"})
+  filter({"platforms:Android-x86_64 or platforms:Linux or platforms:Windows"})
   files({
     "x86/constants.c",
     "x86/fdctdsp_init.c",
@@ -137,7 +137,7 @@ project("libavcodec")
   })
   filter({})
   --   MMX-OBJS:
-  filter({"platforms:Android_x86_64 or platforms:Linux or platforms:Windows"})
+  filter({"platforms:Android-x86_64 or platforms:Linux or platforms:Windows"})
   files({
     "x86/fdct.c",
   })

--- a/libavutil/premake5.lua
+++ b/libavutil/premake5.lua
@@ -195,14 +195,14 @@ project("libavutil")
 
   -- libavutil/aarch64/Makefile:
   --   OBJS:
-  filter({"platforms:Android_ARM64"})
+  filter({"platforms:Android-ARM64"})
   files({
     "aarch64/cpu.c",
     "aarch64/float_dsp_init.c",
   })
   filter({})
   --   NEON-OBJS:
-  filter({"platforms:Android_ARM64"})
+  filter({"platforms:Android-ARM64"})
   files({
     "aarch64/float_dsp_neon.S",
   })
@@ -210,7 +210,7 @@ project("libavutil")
 
   -- libavutil/x86/Makefile:
   --   OBJS:
-  filter({"platforms:Android_x86_64 or platforms:Linux or platforms:Windows"})
+  filter({"platforms:Android-x86_64 or platforms:Linux or platforms:Windows"})
   files({
     "x86/cpu.c",
     "x86/fixed_dsp_init.c",


### PR DESCRIPTION
As `x86_64` contains an underscore too, `-` would be cleaner as a platform separator. Another example of a hyphen being used as a platform separator is LLVM target triples, which also may contain an `x86_64` architecture.